### PR TITLE
feat: support custom netrc file path

### DIFF
--- a/commands/get_command.go
+++ b/commands/get_command.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"os/user"
-	"path/filepath"
 
 	"github.com/jdxcode/netrc"
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -49,7 +47,9 @@ func (c *GetCommand) Examples() map[string]string {
 }
 
 func (c *GetCommand) FlagSet() *pflag.FlagSet {
-	return c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	fs := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	fs.String("netrc-file", "", "path to the netrc file (overrides $NETRC and ~/.netrc)")
+	return fs
 }
 
 func (c *GetCommand) Name() string {
@@ -80,23 +80,15 @@ func (c *GetCommand) Run(args []string) int {
 
 	name := arguments["name"].StringValue()
 
-	usr, err := user.Current()
+	netrcFlag, _ := flags.GetString("netrc-file")
+	netrcFile, err := resolveNetrcPath(netrcFlag)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
-
-	netrcFile := filepath.Join(usr.HomeDir, ".netrc")
-	if _, err := os.Stat(netrcFile); os.IsNotExist(err) {
-		file, err := os.OpenFile(netrcFile, os.O_RDONLY|os.O_CREATE, 0600)
-		if err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
-		if err := file.Close(); err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
+	if err := ensureNetrcExists(netrcFile); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
 	}
 
 	n, err := netrc.Parse(netrcFile)

--- a/commands/netrc_path.go
+++ b/commands/netrc_path.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+func resolveNetrcPath(flagValue string) (string, error) {
+	if flagValue != "" {
+		return filepath.Clean(flagValue), nil
+	}
+
+	if env := os.Getenv("NETRC"); env != "" {
+		return filepath.Clean(env), nil
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(usr.HomeDir, ".netrc"), nil
+}
+
+func ensureNetrcExists(path string) error {
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return err
+	}
+
+	file, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+
+	return file.Close()
+}

--- a/commands/set_command.go
+++ b/commands/set_command.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"os/user"
-	"path/filepath"
 
 	"github.com/jdxcode/netrc"
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -64,7 +62,9 @@ func (c *SetCommand) Examples() map[string]string {
 }
 
 func (c *SetCommand) FlagSet() *pflag.FlagSet {
-	return c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	fs := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	fs.String("netrc-file", "", "path to the netrc file (overrides $NETRC and ~/.netrc)")
+	return fs
 }
 
 func (c *SetCommand) Name() string {
@@ -98,23 +98,15 @@ func (c *SetCommand) Run(args []string) int {
 	password := arguments["password"].StringValue()
 	account := arguments["account"].StringValue()
 
-	usr, err := user.Current()
+	netrcFlag, _ := flags.GetString("netrc-file")
+	netrcFile, err := resolveNetrcPath(netrcFlag)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
-
-	netrcFile := filepath.Join(usr.HomeDir, ".netrc")
-	if _, err := os.Stat(netrcFile); os.IsNotExist(err) {
-		file, err := os.OpenFile(netrcFile, os.O_RDONLY|os.O_CREATE, 0600)
-		if err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
-		if err := file.Close(); err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
+	if err := ensureNetrcExists(netrcFile); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
 	}
 
 	n, err := netrc.Parse(netrcFile)

--- a/commands/unset_command.go
+++ b/commands/unset_command.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"os/user"
-	"path/filepath"
 
 	"github.com/jdxcode/netrc"
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -49,7 +47,9 @@ func (c *UnsetCommand) Examples() map[string]string {
 }
 
 func (c *UnsetCommand) FlagSet() *pflag.FlagSet {
-	return c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	fs := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	fs.String("netrc-file", "", "path to the netrc file (overrides $NETRC and ~/.netrc)")
+	return fs
 }
 
 func (c *UnsetCommand) Name() string {
@@ -80,23 +80,15 @@ func (c *UnsetCommand) Run(args []string) int {
 
 	name := arguments["name"].StringValue()
 
-	usr, err := user.Current()
+	netrcFlag, _ := flags.GetString("netrc-file")
+	netrcFile, err := resolveNetrcPath(netrcFlag)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
-
-	netrcFile := filepath.Join(usr.HomeDir, ".netrc")
-	if _, err := os.Stat(netrcFile); os.IsNotExist(err) {
-		file, err := os.OpenFile(netrcFile, os.O_RDONLY|os.O_CREATE, 0600)
-		if err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
-		if err := file.Close(); err != nil {
-			c.Ui.Error(err.Error())
-			return 1
-		}
+	if err := ensureNetrcExists(netrcFile); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
 	}
 
 	n, err := netrc.Parse(netrcFile)

--- a/test.bats
+++ b/test.bats
@@ -294,6 +294,79 @@ teardown() {
   assert_success
 }
 
+@test "(get) custom path via --netrc-file" {
+  custom="$(mktemp)"
+  cp "fixtures/valid/.netrc" "$custom"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  run $NETRC_BIN get heroku.com --netrc-file "$custom"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "username:longpassword"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  rm -f "$custom"
+}
+
+@test "(get) custom path via NETRC env var" {
+  custom="$(mktemp)"
+  cp "fixtures/valid/.netrc" "$custom"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  NETRC="$custom" run $NETRC_BIN get heroku.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "username:longpassword"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  rm -f "$custom"
+}
+
+@test "(set) custom path via --netrc-file" {
+  custom="$(mktemp)"
+  rm -f "$custom"
+
+  run $NETRC_BIN set github.com username password --netrc-file "$custom"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run cat "$custom"
+  assert_success
+  assert_output "$(cat fixtures/empty/github.netrc)"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  rm -f "$custom"
+}
+
+@test "(--netrc-file flag overrides NETRC env var)" {
+  flag_path="$(mktemp)"
+  env_path="$(mktemp)"
+  cp "fixtures/valid/.netrc" "$flag_path"
+  cp "fixtures/empty/.netrc" "$env_path"
+
+  NETRC="$env_path" run $NETRC_BIN get heroku.com --netrc-file "$flag_path"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "username:longpassword"
+
+  rm -f "$flag_path" "$env_path"
+}
+
 # test functions
 flunk() {
   {


### PR DESCRIPTION
Each subcommand now accepts a `--netrc-file` flag and honors the `NETRC` environment variable, falling back to `~/.netrc` when neither is set. The flag takes precedence over the env var.