### PR TITLE
feat: add list subcommand to enumerate machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Usage: netrc [--version] [--help] <command> [<args>]
 
 Available commands are:
     get      Get an entry from the .netrc file
+    list     List machines in the .netrc file
     set      Set an entry in the .netrc file
     unset    Unset an entry from the .netrc file
     version  Return the version of the binary

--- a/commands/list_command.go
+++ b/commands/list_command.go
@@ -1,0 +1,184 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/jdxcode/netrc"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	"github.com/spf13/pflag"
+)
+
+type ListCommand struct {
+	command.Meta
+}
+
+type machineEntry struct {
+	Name     string `json:"name"`
+	Login    string `json:"login"`
+	Password string `json:"password"`
+	Account  string `json:"account"`
+}
+
+func (c *ListCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *ListCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *ListCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{},
+	)
+}
+
+func (c *ListCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *ListCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"List all machines in the .netrc file":              fmt.Sprintf("%s %s", appName, c.Name()),
+		"List machines including the default block as JSON": fmt.Sprintf("%s %s --include-default --format json", appName, c.Name()),
+	}
+}
+
+func (c *ListCommand) FlagSet() *pflag.FlagSet {
+	fs := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	fs.String("netrc-file", "", "path to the netrc file (overrides $NETRC and ~/.netrc)")
+	fs.String("format", "text", "output format: text or json")
+	fs.Bool("with-fields", false, "include login/password/account for each machine")
+	fs.Bool("include-default", false, "include the default block in the output")
+	return fs
+}
+
+func (c *ListCommand) Name() string {
+	return "list"
+}
+
+func (c *ListCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *ListCommand) Synopsis() string {
+	return "List machines in the .netrc file"
+}
+
+func (c *ListCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	if _, err := c.ParsedArguments(flags.Args()); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	format, _ := flags.GetString("format")
+	if format != "text" && format != "json" {
+		c.Ui.Error(fmt.Sprintf("Invalid format '%s' specified, must be 'text' or 'json'", format))
+		return 1
+	}
+
+	withFields, _ := flags.GetBool("with-fields")
+	includeDefault, _ := flags.GetBool("include-default")
+
+	netrcFlag, _ := flags.GetString("netrc-file")
+	netrcFile, err := resolveNetrcPath(netrcFlag)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	if err := ensureNetrcExists(netrcFile); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	n, err := netrc.Parse(netrcFile)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	machines := make([]*netrc.Machine, 0, len(n.Machines()))
+	for _, m := range n.Machines() {
+		if m.IsDefault && !includeDefault {
+			continue
+		}
+		machines = append(machines, m)
+	}
+
+	if format == "json" {
+		out, err := renderJSON(machines, withFields)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		c.Ui.Output(out)
+		return 0
+	}
+
+	if out := renderText(machines, withFields); out != "" {
+		c.Ui.Output(out)
+	}
+	return 0
+}
+
+func renderText(machines []*netrc.Machine, withFields bool) string {
+	var lines []string
+	for _, m := range machines {
+		if !withFields {
+			lines = append(lines, m.Name)
+			continue
+		}
+		parts := []string{
+			m.Name,
+			fmt.Sprintf("login=%s", m.Get("login")),
+			fmt.Sprintf("password=%s", m.Get("password")),
+		}
+		if account := m.Get("account"); account != "" {
+			parts = append(parts, fmt.Sprintf("account=%s", account))
+		}
+		lines = append(lines, strings.Join(parts, "\t"))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderJSON(machines []*netrc.Machine, withFields bool) (string, error) {
+	if !withFields {
+		names := make([]string, 0, len(machines))
+		for _, m := range machines {
+			names = append(names, m.Name)
+		}
+		b, err := json.MarshalIndent(names, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+
+	entries := make([]machineEntry, 0, len(machines))
+	for _, m := range machines {
+		entries = append(entries, machineEntry{
+			Name:     m.Name,
+			Login:    m.Get("login"),
+			Password: m.Get("password"),
+			Account:  m.Get("account"),
+		})
+	}
+	b, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/fixtures/with-default/.netrc
+++ b/fixtures/with-default/.netrc
@@ -1,0 +1,6 @@
+default
+  login defaultuser
+  password defaultpass
+machine heroku.com
+  login username
+  password longpassword

--- a/main.go
+++ b/main.go
@@ -43,6 +43,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"get": func() (cli.Command, error) {
 			return &commands.GetCommand{Meta: meta}, nil
 		},
+		"list": func() (cli.Command, error) {
+			return &commands.ListCommand{Meta: meta}, nil
+		},
 		"unset": func() (cli.Command, error) {
 			return &commands.UnsetCommand{Meta: meta}, nil
 		},

--- a/test.bats
+++ b/test.bats
@@ -367,6 +367,144 @@ teardown() {
   rm -f "$flag_path" "$env_path"
 }
 
+@test "(list) no netrc" {
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  run $NETRC_BIN list
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run test -f "$HOME/.netrc"
+  assert_success
+}
+
+@test "(list) empty netrc" {
+  run cp "fixtures/empty/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+}
+
+@test "(list) valid netrc" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "heroku.com"
+}
+
+@test "(list) --with-fields" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list --with-fields
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "heroku.com"
+  assert_output_contains "login=username"
+  assert_output_contains "password=longpassword"
+}
+
+@test "(list) --with-fields omits empty account" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list --with-fields
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  [[ "$output" != *"account="* ]] || flunk "expected no account= field for machine without account"
+}
+
+@test "(list) --format=json default" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list --format json
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "\"heroku.com\""
+}
+
+@test "(list) --format=json --with-fields" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list --format json --with-fields
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "\"name\": \"heroku.com\""
+  assert_output_contains "\"login\": \"username\""
+  assert_output_contains "\"password\": \"longpassword\""
+  assert_output_contains "\"account\": \"\""
+}
+
+@test "(list) --format=invalid" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list --format yaml
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid format 'yaml' specified"
+}
+
+@test "(list) default block excluded by default" {
+  run cp "fixtures/with-default/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "heroku.com"
+}
+
+@test "(list) --include-default includes default block" {
+  run cp "fixtures/with-default/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN list --include-default
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "default"
+  assert_output_contains "heroku.com"
+}
+
+@test "(list) custom path via --netrc-file" {
+  custom="$(mktemp)"
+  cp "fixtures/valid/.netrc" "$custom"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  run $NETRC_BIN list --netrc-file "$custom"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "heroku.com"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  rm -f "$custom"
+}
+
 # test functions
 flunk() {
   {


### PR DESCRIPTION
## Summary

Adds a `list` subcommand that enumerates machines in a `.netrc` file. Default text output prints one machine name per line; the `default` block is excluded unless `--include-default` is passed.

## CLI surface

```
netrc list [--with-fields] [--format text|json] [--include-default] [--netrc-file PATH]
```

- `--with-fields`: adds `login=`, `password=`, `account=` columns (text mode, tab-separated; account omitted when empty) or fields (JSON mode).
- `--format json`: emits a JSON array of strings, or of `{name, login, password, account}` objects when combined with `--with-fields`. Empty input renders as `[]`.
- `--netrc-file PATH`: same resolution semantics as the existing commands.

Closes #309