### PR TITLE
feat: add field selection and structured output to get

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,49 @@ Available commands are:
     unset    Unset an entry from the .netrc file
     version  Return the version of the binary
 ```
+
+### get
+
+```text
+netrc get <name> [--field login|password|account ...] [--format=text|json|shell] [--netrc-file PATH]
+```
+
+By default `get` prints `login:password` for back-compatibility:
+
+```console
+$ netrc get github.com
+username:longpassword
+```
+
+Pass `--field` (repeatable) to select specific fields. With a single field, only the value is printed:
+
+```console
+$ netrc get github.com --field password
+longpassword
+```
+
+Multiple `--field` flags emit one `key=value` per line in the order supplied:
+
+```console
+$ netrc get github.com --field login --field password
+login=username
+password=longpassword
+```
+
+Use `--format json` for machine-readable output:
+
+```console
+$ netrc get github.com --field login --field password --format json
+{
+  "login": "username",
+  "password": "longpassword"
+}
+```
+
+Use `--format shell` to emit `eval`-safe assignments (single-quote escaped):
+
+```console
+$ eval "$(netrc get github.com --format shell)"
+$ echo "$login $password"
+username longpassword
+```

--- a/commands/get_command.go
+++ b/commands/get_command.go
@@ -1,14 +1,19 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jdxcode/netrc"
 	"github.com/josegonzalez/cli-skeleton/command"
 	"github.com/posener/complete"
 	"github.com/spf13/pflag"
 )
+
+var validGetFields = []string{"login", "password", "account"}
+var defaultGetFields = []string{"login", "password"}
 
 type GetCommand struct {
 	command.Meta
@@ -42,13 +47,18 @@ func (c *GetCommand) AutocompleteArgs() complete.Predictor {
 func (c *GetCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"Get an entry from the .netrc file": fmt.Sprintf("%s %s github.com", appName, c.Name()),
+		"Get an entry from the .netrc file":             fmt.Sprintf("%s %s github.com", appName, c.Name()),
+		"Get a single field":                            fmt.Sprintf("%s %s github.com --field password", appName, c.Name()),
+		"Get specific fields as JSON":                   fmt.Sprintf("%s %s github.com --field login --field password --format json", appName, c.Name()),
+		"Get fields as eval-safe shell variable assigns": fmt.Sprintf("%s %s github.com --format shell", appName, c.Name()),
 	}
 }
 
 func (c *GetCommand) FlagSet() *pflag.FlagSet {
 	fs := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	fs.String("netrc-file", "", "path to the netrc file (overrides $NETRC and ~/.netrc)")
+	fs.StringArray("field", []string{}, "field to output (login, password, account); repeatable")
+	fs.String("format", "text", "output format: text, json, or shell")
 	return fs
 }
 
@@ -103,9 +113,86 @@ func (c *GetCommand) Run(args []string) int {
 		return 1
 	}
 
-	login := machine.Get("login")
-	password := machine.Get("password")
-	c.Ui.Output(fmt.Sprintf("%s:%s", login, password))
+	format, _ := flags.GetString("format")
+	if format != "text" && format != "json" && format != "shell" {
+		c.Ui.Error(fmt.Sprintf("Invalid format '%s' specified, must be 'text', 'json', or 'shell'", format))
+		return 1
+	}
+
+	fields, _ := flags.GetStringArray("field")
+	userSuppliedFields := len(fields) > 0
+	if !userSuppliedFields {
+		fields = defaultGetFields
+	}
+	for _, f := range fields {
+		if !isValidGetField(f) {
+			c.Ui.Error(fmt.Sprintf("Invalid field '%s' specified, must be one of 'login', 'password', 'account'", f))
+			return 1
+		}
+	}
+
+	if format == "text" && !userSuppliedFields {
+		c.Ui.Output(fmt.Sprintf("%s:%s", machine.Get("login"), machine.Get("password")))
+		return 0
+	}
+
+	switch format {
+	case "json":
+		out, err := renderGetJSON(machine, fields)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		c.Ui.Output(out)
+	case "shell":
+		c.Ui.Output(renderGetShell(machine, fields))
+	default:
+		c.Ui.Output(renderGetText(machine, fields))
+	}
 
 	return 0
+}
+
+func isValidGetField(f string) bool {
+	for _, v := range validGetFields {
+		if v == f {
+			return true
+		}
+	}
+	return false
+}
+
+func renderGetText(m *netrc.Machine, fields []string) string {
+	if len(fields) == 1 {
+		return m.Get(fields[0])
+	}
+	lines := make([]string, 0, len(fields))
+	for _, f := range fields {
+		lines = append(lines, fmt.Sprintf("%s=%s", f, m.Get(f)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func renderGetJSON(m *netrc.Machine, fields []string) (string, error) {
+	out := make(map[string]string, len(fields))
+	for _, f := range fields {
+		out[f] = m.Get(f)
+	}
+	b, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func renderGetShell(m *netrc.Machine, fields []string) string {
+	lines := make([]string, 0, len(fields))
+	for _, f := range fields {
+		lines = append(lines, fmt.Sprintf("%s=%s", f, shellEscape(m.Get(f))))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func shellEscape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/test.bats
+++ b/test.bats
@@ -86,6 +86,170 @@ teardown() {
   assert_output_contains "Invalid machine 'invalid' specified"
 }
 
+@test "(get) back-compat default output" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "username:longpassword"
+}
+
+@test "(get) single field" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com --field password
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "longpassword"
+
+  run $NETRC_BIN get heroku.com --field login
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "username"
+}
+
+@test "(get) multiple fields text format" {
+  run cp "fixtures/valid/github-account.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get github.com --field login --field password --field account
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "login=username
+password=password
+account=account"
+}
+
+@test "(get) field ordering preserved in text" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com --field password --field login
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "password=longpassword
+login=username"
+}
+
+@test "(get) json format default fields" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com --format json
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "\"login\": \"username\""
+  assert_output_contains "\"password\": \"longpassword\""
+  assert_output_contains "\"account\"" 0
+}
+
+@test "(get) json format with explicit fields" {
+  run cp "fixtures/valid/github-account.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get github.com --field login --field account --format json
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "\"login\": \"username\""
+  assert_output_contains "\"account\": \"account\""
+  assert_output_contains "\"password\"" 0
+}
+
+@test "(get) json single field is still object" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com --field password --format json
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "{"
+  assert_output_contains "\"password\": \"longpassword\""
+}
+
+@test "(get) shell format default fields" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com --format shell
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "login='username'
+password='longpassword'"
+
+  unset login password
+  eval "$output"
+  assert_equal "username" "$login"
+  assert_equal "longpassword" "$password"
+}
+
+@test "(get) shell format escapes single quotes" {
+  run $NETRC_BIN set evil.example user "pa'ss"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run $NETRC_BIN get evil.example --field password --format shell
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "password='pa'\\''ss'"
+
+  unset password
+  eval "$output"
+  assert_equal "pa'ss" "$password"
+}
+
+@test "(get) missing field returns empty" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com --field account --format json
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "\"account\": \"\""
+
+  run $NETRC_BIN get heroku.com --field account --format shell
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "account=''"
+}
+
+@test "(get) invalid format rejected" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com --format yaml
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid format 'yaml' specified"
+}
+
+@test "(get) invalid field rejected" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN get heroku.com --field bogus
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid field 'bogus' specified"
+}
+
 @test "(set) no netrc" {
   run test -f "$HOME/.netrc"
   echo "output: $output"


### PR DESCRIPTION
Adds repeatable `--field` and `--format=text|json|shell` flags to the `get` subcommand, closing #310. The bare invocation continues to emit `login:password` for back-compatibility, and shell format produces POSIX single-quote-escaped assignments suitable for `eval`.

Closes #310