### PR TITLE
feat: add --stdin to set for reading passwords without argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,23 @@ $ eval "$(netrc get github.com --format shell)"
 $ echo "$login $password"
 username longpassword
 ```
+
+### set
+
+```text
+netrc set <name> <login> <password> [account] [--netrc-file PATH]
+```
+
+Creates or updates an entry. Passing `account` is optional. With no `--netrc-file` flag, `$NETRC` is consulted, then `~/.netrc`; the file is created with `0600` permissions if it does not exist.
+
+```console
+$ netrc set github.com username longpassword
+```
+
+Pass `--stdin` to read the password from standard input instead of as a positional argument. This keeps the password out of shell history and `ps` output:
+
+```console
+$ echo "$PW" | netrc set github.com username --stdin
+```
+
+With `--stdin`, the password positional is omitted - the form is `netrc set <name> <login> --stdin [account]`. A trailing newline on stdin is stripped; empty stdin is rejected.

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ netrc set <name> <login> <password> [account] [--netrc-file PATH]
 
 Creates or updates an entry. Passing `account` is optional. With no `--netrc-file` flag, `$NETRC` is consulted, then `~/.netrc`; the file is created with `0600` permissions if it does not exist.
 
-```console
-$ netrc set github.com username longpassword
+```text
+netrc set github.com username longpassword
 ```
 
 Pass `--stdin` to read the password from standard input instead of as a positional argument. This keeps the password out of shell history and `ps` output:
 
-```console
-$ echo "$PW" | netrc set github.com username --stdin
+```text
+echo "$PW" | netrc set github.com username --stdin
 ```
 
 With `--stdin`, the password positional is omitted - the form is `netrc set <name> <login> --stdin [account]`. A trailing newline on stdin is stripped; empty stdin is rejected.

--- a/commands/set_command.go
+++ b/commands/set_command.go
@@ -2,7 +2,9 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/jdxcode/netrc"
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -43,6 +45,14 @@ func (c *SetCommand) Arguments() []command.Argument {
 	return args
 }
 
+func (c *SetCommand) stdinArguments() []command.Argument {
+	return []command.Argument{
+		{Name: "name", Optional: false, Type: command.ArgumentString},
+		{Name: "login", Optional: false, Type: command.ArgumentString},
+		{Name: "account", Optional: true, Type: command.ArgumentString},
+	}
+}
+
 func (c *SetCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
@@ -57,13 +67,15 @@ func (c *SetCommand) AutocompleteArgs() complete.Predictor {
 func (c *SetCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"Set an entry in the .netrc file": fmt.Sprintf("%s %s github.com username password", appName, c.Name()),
+		"Set an entry in the .netrc file":          fmt.Sprintf("%s %s github.com username password", appName, c.Name()),
+		"Set an entry, reading password from stdin": fmt.Sprintf("echo \"$PW\" | %s %s github.com username --stdin", appName, c.Name()),
 	}
 }
 
 func (c *SetCommand) FlagSet() *pflag.FlagSet {
 	fs := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	fs.String("netrc-file", "", "path to the netrc file (overrides $NETRC and ~/.netrc)")
+	fs.Bool("stdin", false, "read password from stdin instead of as a positional argument")
 	return fs
 }
 
@@ -86,7 +98,14 @@ func (c *SetCommand) Run(args []string) int {
 		return 1
 	}
 
-	arguments, err := c.ParsedArguments(flags.Args())
+	useStdin, _ := flags.GetBool("stdin")
+
+	argDefs := c.Arguments()
+	if useStdin {
+		argDefs = c.stdinArguments()
+	}
+
+	arguments, err := command.ParseArguments(flags.Args(), argDefs)
 	if err != nil {
 		c.Ui.Error(err.Error())
 		c.Ui.Error(command.CommandErrorText(c))
@@ -95,8 +114,18 @@ func (c *SetCommand) Run(args []string) int {
 
 	name := arguments["name"].StringValue()
 	login := arguments["login"].StringValue()
-	password := arguments["password"].StringValue()
 	account := arguments["account"].StringValue()
+
+	var password string
+	if useStdin {
+		password, err = readPasswordFromStdin(os.Stdin)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+	} else {
+		password = arguments["password"].StringValue()
+	}
 
 	netrcFlag, _ := flags.GetString("netrc-file")
 	netrcFile, err := resolveNetrcPath(netrcFlag)
@@ -118,6 +147,7 @@ func (c *SetCommand) Run(args []string) int {
 	machine := n.Machine(name)
 	if machine == nil {
 		n.AddMachine(name, login, password)
+		machine = n.Machine(name)
 	} else {
 		machine.Set("login", login)
 		machine.Set("password", password)
@@ -133,4 +163,18 @@ func (c *SetCommand) Run(args []string) int {
 	}
 
 	return 0
+}
+
+func readPasswordFromStdin(r io.Reader) (string, error) {
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("failed to read password from stdin: %w", err)
+	}
+
+	password := strings.TrimRight(string(buf), "\n")
+	if password == "" {
+		return "", fmt.Errorf("--stdin given but stdin was empty")
+	}
+
+	return password, nil
 }

--- a/test.bats
+++ b/test.bats
@@ -360,6 +360,74 @@ password='longpassword'"
   assert_output "$(cat fixtures/valid/github-account.netrc)"
 }
 
+@test "(set) stdin reads password" {
+  run bash -c "echo 'password' | $NETRC_BIN set github.com username --stdin"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run cat "$HOME/.netrc"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$(cat fixtures/empty/github.netrc)"
+}
+
+@test "(set) stdin reads password with account" {
+  run bash -c "echo 'password' | $NETRC_BIN set github.com username --stdin account"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run cat "$HOME/.netrc"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "$(cat fixtures/empty/github-account.netrc)"
+}
+
+@test "(set) stdin requires login" {
+  run bash -c "echo 'password' | $NETRC_BIN set github.com --stdin"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "This command requires 2"
+}
+
+@test "(set) stdin rejects empty input" {
+  run bash -c "$NETRC_BIN set github.com username --stdin </dev/null"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "stdin was empty"
+}
+
+@test "(set) stdin strips trailing newline only" {
+  run bash -c "printf 'sneaky' | $NETRC_BIN set example.com user --stdin"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run $NETRC_BIN get example.com --field password
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "sneaky"
+
+  run bash -c "printf 'sneaky\n' | $NETRC_BIN set example.com user --stdin"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run $NETRC_BIN get example.com --field password
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output "sneaky"
+}
+
 @test "(unset) no netrc" {
   run test -f "$HOME/.netrc"
   echo "output: $output"


### PR DESCRIPTION
The set command now accepts --stdin, reading the password from standard input so it does not appear in shell history or process listings. The positional form is unchanged when --stdin is absent. Also fixes a latent nil dereference when account was supplied while creating a brand-new machine.

Closes #311.