### PR TITLE
Allow partial update on set via per-field flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ username longpassword
 
 ```text
 netrc set <name> <login> <password> [account] [--netrc-file PATH]
+netrc set <name> [--login VALUE] [--password VALUE] [--account VALUE] [--netrc-file PATH]
 ```
 
 Creates or updates an entry. Passing `account` is optional. With no `--netrc-file` flag, `$NETRC` is consulted, then `~/.netrc`; the file is created with `0600` permissions if it does not exist.
@@ -88,3 +89,13 @@ echo "$PW" | netrc set github.com username --stdin
 ```
 
 With `--stdin`, the password positional is omitted - the form is `netrc set <name> <login> --stdin [account]`. A trailing newline on stdin is stripped; empty stdin is rejected.
+
+To update a single field on an existing entry without re-supplying the others, pass `--login`, `--password`, or `--account`. When any of those flags is supplied, only the machine name is taken positionally and unspecified fields are preserved:
+
+```text
+netrc set github.com --password newpassword
+netrc set github.com --login newuser
+netrc set github.com --account ""           # clears the account field
+```
+
+`--password` and `--stdin` are mutually exclusive. Creating a brand-new entry via flag mode requires both `--login` and `--password` (the underlying file format does not round-trip empty values for these fields).

--- a/commands/set_command.go
+++ b/commands/set_command.go
@@ -53,6 +53,12 @@ func (c *SetCommand) stdinArguments() []command.Argument {
 	}
 }
 
+func (c *SetCommand) flagArguments() []command.Argument {
+	return []command.Argument{
+		{Name: "name", Optional: false, Type: command.ArgumentString},
+	}
+}
+
 func (c *SetCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
@@ -67,8 +73,9 @@ func (c *SetCommand) AutocompleteArgs() complete.Predictor {
 func (c *SetCommand) Examples() map[string]string {
 	appName := os.Getenv("CLI_APP_NAME")
 	return map[string]string{
-		"Set an entry in the .netrc file":          fmt.Sprintf("%s %s github.com username password", appName, c.Name()),
+		"Set an entry in the .netrc file":           fmt.Sprintf("%s %s github.com username password", appName, c.Name()),
 		"Set an entry, reading password from stdin": fmt.Sprintf("echo \"$PW\" | %s %s github.com username --stdin", appName, c.Name()),
+		"Rotate the password on an existing entry":  fmt.Sprintf("%s %s github.com --password newpassword", appName, c.Name()),
 	}
 }
 
@@ -76,6 +83,9 @@ func (c *SetCommand) FlagSet() *pflag.FlagSet {
 	fs := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	fs.String("netrc-file", "", "path to the netrc file (overrides $NETRC and ~/.netrc)")
 	fs.Bool("stdin", false, "read password from stdin instead of as a positional argument")
+	fs.String("login", "", "set the login field; other fields preserved if the entry exists")
+	fs.String("password", "", "set the password field; other fields preserved if the entry exists")
+	fs.String("account", "", "set the account field; pass an empty string to clear it")
 	return fs
 }
 
@@ -99,9 +109,21 @@ func (c *SetCommand) Run(args []string) int {
 	}
 
 	useStdin, _ := flags.GetBool("stdin")
+	loginChanged := flags.Changed("login")
+	passwordChanged := flags.Changed("password")
+	accountChanged := flags.Changed("account")
+	fieldFlagSet := loginChanged || passwordChanged || accountChanged
+
+	if useStdin && passwordChanged {
+		c.Ui.Error("--stdin and --password are mutually exclusive")
+		return 1
+	}
 
 	argDefs := c.Arguments()
-	if useStdin {
+	switch {
+	case fieldFlagSet:
+		argDefs = c.flagArguments()
+	case useStdin:
 		argDefs = c.stdinArguments()
 	}
 
@@ -112,20 +134,17 @@ func (c *SetCommand) Run(args []string) int {
 		return 1
 	}
 
-	name := arguments["name"].StringValue()
-	login := arguments["login"].StringValue()
-	account := arguments["account"].StringValue()
-
-	var password string
-	if useStdin {
-		password, err = readPasswordFromStdin(os.Stdin)
-		if err != nil {
-			c.Ui.Error(err.Error())
-			return 1
+	positional := func(name string) (string, bool) {
+		if arg, ok := arguments[name]; ok && arg.HasValue {
+			return arg.StringValue(), true
 		}
-	} else {
-		password = arguments["password"].StringValue()
+		return "", false
 	}
+
+	name, _ := positional("name")
+	loginPos, loginPosSet := positional("login")
+	passwordPos, passwordPosSet := positional("password")
+	accountPos, accountPosSet := positional("account")
 
 	netrcFlag, _ := flags.GetString("netrc-file")
 	netrcFile, err := resolveNetrcPath(netrcFlag)
@@ -145,7 +164,56 @@ func (c *SetCommand) Run(args []string) int {
 	}
 
 	machine := n.Machine(name)
+	existingLogin, existingPassword := "", ""
+	if machine != nil {
+		existingLogin = machine.Get("login")
+		existingPassword = machine.Get("password")
+	}
+
+	loginFlag, _ := flags.GetString("login")
+	passwordFlag, _ := flags.GetString("password")
+	accountFlag, _ := flags.GetString("account")
+
+	login := existingLogin
+	switch {
+	case loginChanged:
+		login = loginFlag
+	case loginPosSet:
+		login = loginPos
+	}
+
+	var password string
+	switch {
+	case passwordChanged:
+		password = passwordFlag
+	case useStdin:
+		password, err = readPasswordFromStdin(os.Stdin)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+	case passwordPosSet:
+		password = passwordPos
+	default:
+		password = existingPassword
+	}
+
+	account := ""
+	accountTouched := false
+	switch {
+	case accountChanged:
+		account = accountFlag
+		accountTouched = true
+	case accountPosSet && accountPos != "":
+		account = accountPos
+		accountTouched = true
+	}
+
 	if machine == nil {
+		if login == "" || password == "" {
+			c.Ui.Error(fmt.Sprintf("Cannot create new entry '%s' without login and password", name))
+			return 1
+		}
 		n.AddMachine(name, login, password)
 		machine = n.Machine(name)
 	} else {
@@ -153,7 +221,7 @@ func (c *SetCommand) Run(args []string) int {
 		machine.Set("password", password)
 	}
 
-	if account != "" {
+	if accountTouched {
 		machine.Set("account", account)
 	}
 

--- a/test.bats
+++ b/test.bats
@@ -428,6 +428,141 @@ password='longpassword'"
   assert_output "sneaky"
 }
 
+@test "(set) --password updates only password" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN set heroku.com --password newpw
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run $NETRC_BIN get heroku.com --field login
+  assert_success
+  assert_output "username"
+
+  run $NETRC_BIN get heroku.com --field password
+  assert_success
+  assert_output "newpw"
+}
+
+@test "(set) --login updates only login" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN set heroku.com --login newuser
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run $NETRC_BIN get heroku.com --field login
+  assert_success
+  assert_output "newuser"
+
+  run $NETRC_BIN get heroku.com --field password
+  assert_success
+  assert_output "longpassword"
+}
+
+@test "(set) --account updates only account" {
+  run cp "fixtures/valid/github-account.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN set github.com --account newacct
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run $NETRC_BIN get github.com --field login
+  assert_success
+  assert_output "username"
+
+  run $NETRC_BIN get github.com --field password
+  assert_success
+  assert_output "password"
+
+  run $NETRC_BIN get github.com --field account
+  assert_success
+  assert_output "newacct"
+}
+
+@test "(set) --account empty clears account" {
+  run cp "fixtures/valid/github-account.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN set github.com --account ""
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run $NETRC_BIN get github.com --field account
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output ""
+}
+
+@test "(set) flag mode rejects extra positionals" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN set heroku.com extrauser --login alice
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "This command requires 1 argument"
+}
+
+@test "(set) --password and --stdin are mutually exclusive" {
+  run bash -c "echo 'pw' | $NETRC_BIN set github.com --stdin --password other"
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "--stdin and --password are mutually exclusive"
+}
+
+@test "(set) flag mode rejects new machine with missing login or password" {
+  run cp "fixtures/empty/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN set newhost.com --password pw
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Cannot create new entry 'newhost.com' without login and password"
+
+  run $NETRC_BIN set newhost.com --login user --password pw
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run $NETRC_BIN get newhost.com --field login
+  assert_success
+  assert_output "user"
+
+  run $NETRC_BIN get newhost.com --field password
+  assert_success
+  assert_output "pw"
+}
+
+@test "(set) positional regression with no flags still works" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN set github.com username password account
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+
+  run cat "$HOME/.netrc"
+  assert_success
+  assert_output "$(cat fixtures/valid/github-account.netrc)"
+}
+
 @test "(unset) no netrc" {
   run test -f "$HOME/.netrc"
   echo "output: $output"


### PR DESCRIPTION
Adds `--login`, `--password`, and `--account` flags to `netrc set`. When any of these is supplied, only the machine name is taken positionally and unspecified fields are preserved by reading the current value from the existing entry, so callers can rotate a single field without re-supplying the others. The 3- and 4-positional forms are unchanged. `--password` and `--stdin` are mutually exclusive, and creating a brand-new entry via flag mode requires both login and password since the underlying file format does not round-trip empty values.

Closes #312