### PR TITLE
feat: add rename subcommand to move entries without resupplying fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Usage: netrc [--version] [--help] <command> [<args>]
 Available commands are:
     get      Get an entry from the .netrc file
     list     List machines in the .netrc file
+    rename   Rename an entry in the .netrc file
     set      Set an entry in the .netrc file
     unset    Unset an entry from the .netrc file
     version  Return the version of the binary
@@ -99,3 +100,23 @@ netrc set github.com --account ""           # clears the account field
 ```
 
 `--password` and `--stdin` are mutually exclusive. Creating a brand-new entry via flag mode requires both `--login` and `--password` (the underlying file format does not round-trip empty values for these fields).
+
+### rename
+
+```text
+netrc rename <old-name> <new-name> [--force] [--netrc-file PATH]
+```
+
+Renames a machine, copying all of its fields (`login`, `password`, `account`) to the new name. This avoids the `unset` + `set` workaround, which forces the caller to know and re-supply every field.
+
+```text
+netrc rename old.example.com new.example.com
+```
+
+The command exits with an error if the source machine does not exist, or if the destination machine already exists. Pass `--force` to overwrite an existing destination; a warning is printed to stderr when this happens so the destructive overwrite is visible.
+
+```text
+netrc rename old.example.com new.example.com --force
+```
+
+When `<old-name>` and `<new-name>` are equal the command is a no-op and the file is left untouched.

--- a/commands/rename_command.go
+++ b/commands/rename_command.go
@@ -1,0 +1,144 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jdxcode/netrc"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	"github.com/spf13/pflag"
+)
+
+type RenameCommand struct {
+	command.Meta
+}
+
+func (c *RenameCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *RenameCommand) Arguments() []command.Argument {
+	args := []command.Argument{}
+	args = append(args, command.Argument{
+		Name:     "old-name",
+		Optional: false,
+		Type:     command.ArgumentString,
+	})
+	args = append(args, command.Argument{
+		Name:     "new-name",
+		Optional: false,
+		Type:     command.ArgumentString,
+	})
+	return args
+}
+
+func (c *RenameCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{},
+	)
+}
+
+func (c *RenameCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *RenameCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Rename an entry in the .netrc file":             fmt.Sprintf("%s %s old.example.com new.example.com", appName, c.Name()),
+		"Overwrite an existing destination with --force": fmt.Sprintf("%s %s old.example.com new.example.com --force", appName, c.Name()),
+	}
+}
+
+func (c *RenameCommand) FlagSet() *pflag.FlagSet {
+	fs := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	fs.String("netrc-file", "", "path to the netrc file (overrides $NETRC and ~/.netrc)")
+	fs.Bool("force", false, "overwrite the destination machine if it already exists")
+	return fs
+}
+
+func (c *RenameCommand) Name() string {
+	return "rename"
+}
+
+func (c *RenameCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *RenameCommand) Synopsis() string {
+	return "Rename an entry in the .netrc file"
+}
+
+func (c *RenameCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	arguments, err := c.ParsedArguments(flags.Args())
+	if err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	oldName := arguments["old-name"].StringValue()
+	newName := arguments["new-name"].StringValue()
+	force, _ := flags.GetBool("force")
+
+	netrcFlag, _ := flags.GetString("netrc-file")
+	netrcFile, err := resolveNetrcPath(netrcFlag)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	if err := ensureNetrcExists(netrcFile); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	n, err := netrc.Parse(netrcFile)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	src := n.Machine(oldName)
+	if src == nil {
+		c.Ui.Error(fmt.Sprintf("Invalid machine '%s' specified", oldName))
+		return 1
+	}
+
+	if oldName == newName {
+		return 0
+	}
+
+	login := src.Get("login")
+	password := src.Get("password")
+	account := src.Get("account")
+
+	if dst := n.Machine(newName); dst != nil {
+		if !force {
+			c.Ui.Error(fmt.Sprintf("Machine '%s' already exists, pass --force to overwrite", newName))
+			return 1
+		}
+		c.Ui.Warn(fmt.Sprintf("Warning: overwriting existing machine '%s'", newName))
+		n.RemoveMachine(newName)
+	}
+
+	n.AddMachine(newName, login, password)
+	if account != "" {
+		n.Machine(newName).Set("account", account)
+	}
+	n.RemoveMachine(oldName)
+
+	if err := n.Save(); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	return 0
+}

--- a/main.go
+++ b/main.go
@@ -46,6 +46,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"list": func() (cli.Command, error) {
 			return &commands.ListCommand{Meta: meta}, nil
 		},
+		"rename": func() (cli.Command, error) {
+			return &commands.RenameCommand{Meta: meta}, nil
+		},
 		"unset": func() (cli.Command, error) {
 			return &commands.UnsetCommand{Meta: meta}, nil
 		},

--- a/test.bats
+++ b/test.bats
@@ -661,6 +661,141 @@ password='longpassword'"
   assert_success
 }
 
+@test "(rename) preserves login, password, account" {
+  run cp "fixtures/valid/github-account.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN rename github.com gh.example.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run $NETRC_BIN get github.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid machine 'github.com' specified"
+
+  run $NETRC_BIN get gh.example.com --field login
+  assert_success
+  assert_output "username"
+
+  run $NETRC_BIN get gh.example.com --field password
+  assert_success
+  assert_output "password"
+
+  run $NETRC_BIN get gh.example.com --field account
+  assert_success
+  assert_output "account"
+}
+
+@test "(rename) missing source errors" {
+  run cp "fixtures/empty/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN rename ghost.com new.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid machine 'ghost.com' specified"
+}
+
+@test "(rename) destination exists errors without --force" {
+  run cp "fixtures/valid/github.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN rename heroku.com github.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Machine 'github.com' already exists, pass --force to overwrite"
+
+  run cat "$HOME/.netrc"
+  assert_success
+  assert_output "$(cat fixtures/valid/github.netrc)"
+}
+
+@test "(rename) --force overwrites destination and warns" {
+  run cp "fixtures/valid/github.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN rename heroku.com github.com --force
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "Warning: overwriting existing machine 'github.com'"
+
+  run $NETRC_BIN get heroku.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "Invalid machine 'heroku.com' specified"
+
+  run $NETRC_BIN get github.com --field login
+  assert_success
+  assert_output "username"
+
+  run $NETRC_BIN get github.com --field password
+  assert_success
+  assert_output "longpassword"
+}
+
+@test "(rename) old equals new is a no-op" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN rename heroku.com heroku.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run cat "$HOME/.netrc"
+  assert_success
+  assert_output "$(cat fixtures/valid/.netrc)"
+}
+
+@test "(rename) custom path via --netrc-file" {
+  custom="$(mktemp)"
+  cp "fixtures/valid/github-account.netrc" "$custom"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  run $NETRC_BIN rename github.com gh.example.com --netrc-file "$custom"
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_not_exists
+
+  run $NETRC_BIN get gh.example.com --field account --netrc-file "$custom"
+  assert_success
+  assert_output "account"
+
+  run test -f "$HOME/.netrc"
+  assert_failure
+
+  rm -f "$custom"
+}
+
+@test "(rename) requires both arguments" {
+  run cp "fixtures/valid/.netrc" "$HOME/.netrc"
+  assert_success
+
+  run $NETRC_BIN rename
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "This command requires 2 arguments"
+
+  run $NETRC_BIN rename heroku.com
+  echo "output: $output"
+  echo "status: $status"
+  assert_failure
+  assert_output_contains "This command requires 2 arguments"
+}
+
 @test "(get) custom path via --netrc-file" {
   custom="$(mktemp)"
   cp "fixtures/valid/.netrc" "$custom"


### PR DESCRIPTION
Closes #313.

Renaming a machine previously required `unset` plus `set`, which forced the caller to know and re-supply `login`, `password`, and `account`. The new `rename` subcommand copies all fields from the source to the destination in a single step. It refuses to clobber an existing destination unless `--force` is passed, and emits a stderr warning when `--force` overwrites.