### PR TITLE
fix: bump json gem to 2.21.2 to patch CVE-2026-54696

### DIFF
--- a/.github/Gemfile.lock
+++ b/.github/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
     http-cookie (1.1.0)
       domain_name (~> 0.5)
     insist (1.0.0)
-    json (2.15.2.1)
+    json (2.21.2)
     logger (1.7.0)
     mime-types (3.7.0)
       logger


### PR DESCRIPTION
Moves the transitive `json` gem in `.github/Gemfile.lock` from `2.15.2.1` to `2.21.2`, resolving `GHSA-x2f5-4prf-w687` (`CVE-2026-54696`), a heap buffer overflow on the `JSON.dump(obj, io)` streaming path. The gem is pulled in by `package_cloud` and `fpm` for the tagged-release packaging workflow and remains within the `json (~> 2.9)` constraint.
